### PR TITLE
prisma.serviceの実装

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { PrismaModule } from 'src/prisma/prisma.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [AuthController],
   providers: [AuthService],
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,11 @@ import * as csurf from 'csurf';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+  app.enableCors({
+    credentials: true,
+    origin: ['http://localhost:3000'],
+  });
   await app.listen(3005);
 }
 bootstrap();

--- a/src/prisma/prisma.module.ts
+++ b/src/prisma/prisma.module.ts
@@ -3,5 +3,6 @@ import { PrismaService } from './prisma.service';
 
 @Module({
   providers: [PrismaService],
+  exports: [PrismaService],
 })
 export class PrismaModule {}

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,4 +1,16 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PrismaClient } from '@prisma/client';
 
 @Injectable()
-export class PrismaService {}
+export class PrismaService extends PrismaClient {
+  constructor(private readonly config: ConfigService) {
+    super({
+      datasources: {
+        db: {
+          url: config.get('DATABASE_URL'),
+        },
+      },
+    });
+  }
+}

--- a/src/todo/todo.module.ts
+++ b/src/todo/todo.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { PrismaModule } from 'src/prisma/prisma.module';
 import { TodoController } from './todo.controller';
 import { TodoService } from './todo.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [TodoController],
   providers: [TodoService],
 })

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
+import { PrismaModule } from 'src/prisma/prisma.module';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [UserController],
-  providers: [UserService]
+  providers: [UserService],
 })
 export class UserModule {}


### PR DESCRIPTION
## 実施内容
- app.module.ts
```
 configモジュールをプロジェクト全体にグローバルでインポート
```
- main.ts
```
- バリデージョン有効化
- コロスの設定（フロントとバックでJWT Tokenをcookieベースで通信、許可するフロントエンドのドメイン指定、cookie-parser）
```
- prisma.service.ts
```
PrismaClientの継承、datasourcesの設定
```
- prisma.module.ts
```
モジュールにexportsを追加し、このモジュールをimportするだけでPrismaServiceを使えるよう設定
```
- auth,user,todoのmodule.tsにimportsを追加
