### PR TITLE
loginメソッド内でエラー発生してしまう問題を解消

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,7 +15,7 @@ model User {
   id Int @id @default(autoincrement())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  email String
+  email String @unique
   hasedPassword String
   tasks Task[]
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -27,7 +27,7 @@ export class AuthService {
     // 受け取ったemailとハッシュ化されたpasswordをPrismaServiceのメソッドを使って、データベースにクリエイトしていく
     // 例外処理トライキャッチ
     try {
-      //prismaサービスのメソッドを呼び出し、prisma/schema.prismaのuserテーブルに対応している
+      //prismaサービスのメソッドを呼び出し、prisma/schema.prismaのuserテーブルに対応している。
       //createをつけることでここにデータを入れられる
       await this.prisma.user.create({
         // dataというフィールドを作ってemailとpasswordを渡す
@@ -58,7 +58,7 @@ export class AuthService {
   // 引数でemailとpasswordをAuthのdtoとして受け取れるようにする
   async login(dto: AuthDto): Promise<Jwt> {
     // dtoからemailを取り出してemailに対応するユーザーが存在するのか検証
-    const user = await this.prisma.user.findUnique({
+    const user = await this.prisma.user.findFirst({
       where: {
         email: dto.email,
       },


### PR DESCRIPTION
auth.service.tsのログインメソッド内でwhere部分にてエラー発生してしまう問題を解決。
（一時的に、index.d.ts内のwhereをanyにすることで解消していた）

schema.prismaにてemail部分に@uniqueを追加し、
auth.service.tsにて以下の部分をfindUniqueからfindFirstへ変更。

＝＝＝＝
const user = await this.prisma.user.findFirst({
      where: {
        email: dto.email,
      },
    });
＝＝＝＝